### PR TITLE
Add Optional Command Override 

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,7 +1,6 @@
-import { App, Plugin, PluginSettingTab, Setting, Notice, normalizePath } from 'obsidian';
 import * as fs from 'fs';
-
-const { exec } = require('child_process');
+import { exec, ExecException } from 'child_process';
+import { App, Plugin, PluginSettingTab, Setting, Notice, normalizePath } from 'obsidian';
 
 interface QuartzPublishButtonPluginSettings {
     quartzPath: string;
@@ -71,7 +70,7 @@ export default class QuartzPublishButtonPlugin extends Plugin {
             ? this.settings.commandOverride 
             : `cd ${this.settings.quartzPath} && npx quartz sync`;
 
-        exec(command, (error, stdout, stderr) => {
+        exec(command, (error: ExecException | null, stdout: string, stderr: string) => {
             if (error) {
                 new Notice(`Execution Error: ${error.message}`, 40000);
                 return;


### PR DESCRIPTION
I installed the plugin and set the `Quartz Repository Location` to the path which is `/Users/gabriel/Data/Projects/Seption/seption.org` but when I click the rocket icon in the sidebar, I get 2 toast notifications in Obsidian: one that says `Publishing with Quartz...` and another that says this:
<img width="311" alt="Screenshot 2024-08-27 at 9 50 03 AM" src="https://github.com/user-attachments/assets/1b868526-e46c-46d9-b367-1537c87870b3">

I believe this is because I am using [zsh](https://www.zsh.org/) instead of [sh](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/sh.html). My default shell on mac is set to `zsh` but it seems from the error message that the plugin is still being called with `sh`.

I tried looking into Obsidian's settings to see if I could change my default shell there but it doesn't seem that is possible.

To run this plugin's command using zsh, I would need the command to be `zsh -c 'cd ${this.settings.quartzPath} && npx quartz sync'`

In this PR, I have added an optional field called `Command Override` that will let you enter in the entire command yourself for situations like the above.

So for me, I would just need to enter `zsh -c 'cd /Users/gabriel/Data/Projects/Seption/seption.org && npx quartz sync'` into the `Command Override` field.